### PR TITLE
add p_column_names, updates to v_xquery strings

### DIFF
--- a/oos_transform.pks
+++ b/oos_transform.pks
@@ -18,15 +18,20 @@ create or replace package oos_transform is
   -- transforms a ref cursor to csv (xquery implementation)
   function refcur2csv(
     p_rc in sys_refcursor
+   ,p_column_names in boolean default false
   ) return clob;
 
   -- transforms a ref cursor to csv (dbms_sql implementation)
   function refcur2csv2(
     p_rc        in out sys_refcursor
+   ,p_column_names in boolean default false
    ,p_separator in varchar2 default ','
-   ,p_endline   in varchar2 default chr(10)||chr(13)
+   ,p_endline   in varchar2 default chr(13)||chr(10)
    ,p_date_fmt  in varchar2 default 'YYYY-MM-DD HH24:MI:SS'
   ) return clob;
+
+  -- decodes any encoded xml entities (e.g. double quotes and ampersand)
+  function entity_decode(p_in clob) return clob;
 
 end;
 /

--- a/oos_transform_example.sql
+++ b/oos_transform_example.sql
@@ -52,7 +52,7 @@ declare
 </table>]';
 begin
   open v_rc for
-    select level, dummy from dual
+    select level, q'[test"quotes'and,commas]' dummy, sysdate from dual
     connect by level < 4
   ;
 
@@ -60,7 +60,7 @@ begin
   dbms_output.put_line(v_xml1.getclobval());
 
   v_xml2 := oos_transform.xslt(v_xml1, v_xslt);
-  dbms_output.put_line(v_xml2.getclobval());
+  dbms_output.put_line(oos_transform.entity_decode(v_xml2.getclobval()));
 
   v_xml2 := oos_transform.xquery(v_xml1, v_xquery);
   dbms_output.put_line(v_xml2.getclobval());
@@ -71,10 +71,10 @@ declare
   v_rc sys_refcursor;
 begin
   open v_rc for
-    select level, dummy, sysdate from dual
+    select level, q'[test"quotes'and,commas]' dummy, sysdate from dual
     connect by level < 4
   ;
-  dbms_output.put_line(oos_transform.refcur2csv(v_rc));
+  dbms_output.put_line(oos_transform.refcur2csv(v_rc, true));
 end;
 /
 
@@ -82,7 +82,7 @@ declare
   v_rc sys_refcursor;
 begin
   open v_rc for
-    select level, dummy, sysdate from dual
+    select level, q'[test"quotes'and,commas]' dummy, sysdate from dual
     connect by level < 4
   ;
   dbms_output.put_line(oos_transform.refcur2csv2(v_rc));


### PR DESCRIPTION
update refcur2csv and refcur2csv2 to wrap fields in quotes and escape double quotes and output column names based on value of p_column_names
update refcur2csv2 parameter default for p_endline to match Windows CRLF format
add URL to supporting documentation for valid col_type numbers returned by dbms_sql.describe_columns3
add entity_decode procedure to decode xml entities in the generated clobs
